### PR TITLE
Fix exit node toggle using AyatanaAppIndicator3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+PREFIX=/usr/share/tailscale-systray
+BINDIR=/usr/local/bin
+AUTOSTART_DIR=/etc/xdg/autostart
+DESKTOP_DIR=/usr/share/applications
+
+echo "Installing system dependencies..."
+apt update
+apt install -y gir1.2-ayatanaappindicator3-0.1
+
+echo "Setting tailscale operator to $SUDO_USER..."
+tailscale set --operator="$SUDO_USER"
+
+echo "Installing tailscale-systray..."
+install -d "$PREFIX"
+install -m 644 src/tailscale_systray.py "$PREFIX/"
+install -m 644 assets/*.png "$PREFIX/"
+
+install -d "$BINDIR"
+printf '#!/bin/sh\nexec python3 %s/tailscale_systray.py "$@"\n' "$PREFIX" > "$BINDIR/tailscale-systray"
+chmod 755 "$BINDIR/tailscale-systray"
+
+install -d "$AUTOSTART_DIR"
+install -m 644 tailscale-systray.desktop "$AUTOSTART_DIR/"
+
+install -d "$DESKTOP_DIR"
+install -m 644 tailscale-systray.desktop "$DESKTOP_DIR/"
+
+echo "Done. Tailscale Systray will start on next login, or run 'tailscale-systray' now."

--- a/src/tailscale_systray.py
+++ b/src/tailscale_systray.py
@@ -5,8 +5,8 @@ import json
 from threading import Thread
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('AppIndicator3', '0.1')
-from gi.repository import Gtk, AppIndicator3, GLib
+gi.require_version('AyatanaAppIndicator3', '0.1')
+from gi.repository import Gtk, AyatanaAppIndicator3 as AppIndicator3, GLib
 
 class TailscaleInterface:
     def __init__(self):
@@ -119,6 +119,7 @@ class TailscaleInterface:
                     if node_info.get('ExitNodeOption', False):
                         exit_node_hosts.append(node_info.get('HostName'))
                 return exit_node_hosts
+            return []
         except Exception as e:
             print(e)
             return []

--- a/tailscale-systray.desktop
+++ b/tailscale-systray.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
-Name=TailscaleSystray
+Name=Tailscale Systray
 Version=1.0
-Exec=python3 /usr/share/tailscale-systray/tailscale_systray.py
+Exec=tailscale-systray
 Icon=/usr/share/tailscale-systray/tailscale-logo-blue.png
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
- Fix exit node toggle by switching to AyatanaAppIndicator3 and setting tailscale operator on install